### PR TITLE
fix/5/vscode-refactorr: Format code using VSCode with Black, isort, and flake8fix: auto-format using VSCode (black, isort, flake8)

### DIFF
--- a/nonstandardcode.py
+++ b/nonstandardcode.py
@@ -42,7 +42,9 @@ def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
 def load_housing_data(housing_path=HOUSING_PATH):
     csv_path = os.path.join(housing_path, "housing.csv")
     if not os.path.exists(csv_path):
-        raise FileNotFoundError(f"Could not find {csv_path}. Did the download fail?")
+        raise FileNotFoundError(
+            f"Could not find {csv_path}. Did the download fail?"
+        )
     return pd.read_csv(csv_path)
 
 
@@ -100,8 +102,12 @@ housing.plot(kind="scatter", x="longitude", y="latitude")
 housing.plot(kind="scatter", x="longitude", y="latitude", alpha=0.1)
 
 housing["rooms_per_household"] = housing["total_rooms"] / housing["households"]
-housing["bedrooms_per_room"] = housing["total_bedrooms"] / housing["total_rooms"]
-housing["population_per_household"] = housing["population"] / housing["households"]
+housing["bedrooms_per_room"] = (
+    housing["total_bedrooms"] / housing["total_rooms"]
+)
+housing["population_per_household"] = (
+    housing["population"] / housing["households"]
+)
 
 housing = strat_train_set.drop("median_house_value", axis=1)
 housing_labels = strat_train_set["median_house_value"].copy()
@@ -112,7 +118,9 @@ imputer.fit(housing_num)
 X = imputer.transform(housing_num)
 
 housing_tr = pd.DataFrame(X, columns=housing_num.columns, index=housing.index)
-housing_tr["rooms_per_household"] = housing_tr["total_rooms"] / housing_tr["households"]
+housing_tr["rooms_per_household"] = (
+    housing_tr["total_rooms"] / housing_tr["households"]
+)
 housing_tr["bedrooms_per_room"] = (
     housing_tr["total_bedrooms"] / housing_tr["total_rooms"]
 )
@@ -121,7 +129,9 @@ housing_tr["population_per_household"] = (
 )
 
 housing_cat = housing[["ocean_proximity"]]
-housing_prepared = housing_tr.join(pd.get_dummies(housing_cat, drop_first=True))
+housing_prepared = housing_tr.join(
+    pd.get_dummies(housing_cat, drop_first=True)
+)
 
 lin_reg = LinearRegression()
 lin_reg.fit(housing_prepared, housing_labels)
@@ -205,7 +215,9 @@ X_test_prepared["population_per_household"] = (
 )
 
 X_test_cat = X_test[["ocean_proximity"]]
-X_test_prepared = X_test_prepared.join(pd.get_dummies(X_test_cat, drop_first=True))
+X_test_prepared = X_test_prepared.join(
+    pd.get_dummies(X_test_cat, drop_first=True)
+)
 
 final_predictions = final_model.predict(X_test_prepared)
 final_mse = mean_squared_error(y_test, final_predictions)

--- a/nonstandardcode.py
+++ b/nonstandardcode.py
@@ -1,0 +1,212 @@
+import os
+import tarfile
+import urllib.request
+
+import numpy as np
+import pandas as pd
+from scipy.stats import randint
+from six.moves import urllib
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+from sklearn.model_selection import (
+    GridSearchCV,
+    RandomizedSearchCV,
+    StratifiedShuffleSplit,
+    train_test_split,
+)
+from sklearn.tree import DecisionTreeRegressor
+
+DOWNLOAD_ROOT = "https://raw.githubusercontent.com/ageron/handson-ml/master/"
+HOUSING_PATH = os.path.join("datasets", "housing")
+HOUSING_URL = DOWNLOAD_ROOT + "datasets/housing/housing.tgz"
+
+
+def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
+    try:
+        os.makedirs(housing_path, exist_ok=True)
+        tgz_path = os.path.join(housing_path, "housing.tgz")
+        print(f"Downloading data from {housing_url}...")
+        urllib.request.urlretrieve(housing_url, tgz_path)
+        print("Extracting data...")
+        housing_tgz = tarfile.open(tgz_path)
+        housing_tgz.extractall(path=housing_path)
+        housing_tgz.close()
+        print("Data downloaded and extracted successfully!")
+    except Exception as e:
+        print(f"Error downloading/extracting data: {e}")
+        raise
+
+
+def load_housing_data(housing_path=HOUSING_PATH):
+    csv_path = os.path.join(housing_path, "housing.csv")
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(f"Could not find {csv_path}. Did the download fail?")
+    return pd.read_csv(csv_path)
+
+
+# Fetch and load the housing data
+fetch_housing_data()
+housing = load_housing_data()
+
+# Verify the data loaded correctly
+print("\nData verification:")
+print(f"Data shape: {housing.shape}")
+print(f"Columns: {housing.columns.tolist()}")
+print("\nFirst 5 rows:")
+print(housing.head())
+
+if housing.empty:
+    raise ValueError("Loaded housing data is empty!")
+
+housing["income_cat"] = pd.cut(
+    housing["median_income"],
+    bins=[0.0, 1.5, 3.0, 4.5, 6.0, np.inf],
+    labels=[1, 2, 3, 4, 5],
+)
+
+train_set, test_set = train_test_split(housing, test_size=0.2, random_state=42)
+
+split = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=42)
+for train_index, test_index in split.split(housing, housing["income_cat"]):
+    strat_train_set = housing.loc[train_index]
+    strat_test_set = housing.loc[test_index]
+
+
+def income_cat_proportions(data):
+    return data["income_cat"].value_counts() / len(data)
+
+
+compare_props = pd.DataFrame(
+    {
+        "Overall": income_cat_proportions(housing),
+        "Stratified": income_cat_proportions(strat_test_set),
+        "Random": income_cat_proportions(test_set),
+    }
+).sort_index()
+compare_props["Rand. %error"] = (
+    100 * compare_props["Random"] / compare_props["Overall"] - 100
+)
+compare_props["Strat. %error"] = (
+    100 * compare_props["Stratified"] / compare_props["Overall"] - 100
+)
+
+for set_ in (strat_train_set, strat_test_set):
+    set_.drop("income_cat", axis=1, inplace=True)
+
+housing = strat_train_set.copy()
+housing.plot(kind="scatter", x="longitude", y="latitude")
+housing.plot(kind="scatter", x="longitude", y="latitude", alpha=0.1)
+
+housing["rooms_per_household"] = housing["total_rooms"] / housing["households"]
+housing["bedrooms_per_room"] = housing["total_bedrooms"] / housing["total_rooms"]
+housing["population_per_household"] = housing["population"] / housing["households"]
+
+housing = strat_train_set.drop("median_house_value", axis=1)
+housing_labels = strat_train_set["median_house_value"].copy()
+
+imputer = SimpleImputer(strategy="median")
+housing_num = housing.drop("ocean_proximity", axis=1)
+imputer.fit(housing_num)
+X = imputer.transform(housing_num)
+
+housing_tr = pd.DataFrame(X, columns=housing_num.columns, index=housing.index)
+housing_tr["rooms_per_household"] = housing_tr["total_rooms"] / housing_tr["households"]
+housing_tr["bedrooms_per_room"] = (
+    housing_tr["total_bedrooms"] / housing_tr["total_rooms"]
+)
+housing_tr["population_per_household"] = (
+    housing_tr["population"] / housing_tr["households"]
+)
+
+housing_cat = housing[["ocean_proximity"]]
+housing_prepared = housing_tr.join(pd.get_dummies(housing_cat, drop_first=True))
+
+lin_reg = LinearRegression()
+lin_reg.fit(housing_prepared, housing_labels)
+
+housing_predictions = lin_reg.predict(housing_prepared)
+lin_mse = mean_squared_error(housing_labels, housing_predictions)
+lin_rmse = np.sqrt(lin_mse)
+lin_rmse
+
+lin_mae = mean_absolute_error(housing_labels, housing_predictions)
+lin_mae
+
+tree_reg = DecisionTreeRegressor(random_state=42)
+tree_reg.fit(housing_prepared, housing_labels)
+
+housing_predictions = tree_reg.predict(housing_prepared)
+tree_mse = mean_squared_error(housing_labels, housing_predictions)
+tree_rmse = np.sqrt(tree_mse)
+tree_rmse
+
+param_distribs = {
+    "n_estimators": randint(low=1, high=200),
+    "max_features": randint(low=1, high=8),
+}
+
+forest_reg = RandomForestRegressor(random_state=42)
+rnd_search = RandomizedSearchCV(
+    forest_reg,
+    param_distributions=param_distribs,
+    n_iter=10,
+    cv=5,
+    scoring="neg_mean_squared_error",
+    random_state=42,
+)
+rnd_search.fit(housing_prepared, housing_labels)
+cvres = rnd_search.cv_results_
+for mean_score, params in zip(cvres["mean_test_score"], cvres["params"]):
+    print(np.sqrt(-mean_score), params)
+
+param_grid = [
+    {"n_estimators": [3, 10, 30], "max_features": [2, 4, 6, 8]},
+    {"bootstrap": [False], "n_estimators": [3, 10], "max_features": [2, 3, 4]},
+]
+
+forest_reg = RandomForestRegressor(random_state=42)
+grid_search = GridSearchCV(
+    forest_reg,
+    param_grid,
+    cv=5,
+    scoring="neg_mean_squared_error",
+    return_train_score=True,
+)
+grid_search.fit(housing_prepared, housing_labels)
+
+grid_search.best_params_
+cvres = grid_search.cv_results_
+for mean_score, params in zip(cvres["mean_test_score"], cvres["params"]):
+    print(np.sqrt(-mean_score), params)
+
+feature_importances = grid_search.best_estimator_.feature_importances_
+sorted(zip(feature_importances, housing_prepared.columns), reverse=True)
+
+final_model = grid_search.best_estimator_
+
+X_test = strat_test_set.drop("median_house_value", axis=1)
+y_test = strat_test_set["median_house_value"].copy()
+
+X_test_num = X_test.drop("ocean_proximity", axis=1)
+X_test_prepared = imputer.transform(X_test_num)
+X_test_prepared = pd.DataFrame(
+    X_test_prepared, columns=X_test_num.columns, index=X_test.index
+)
+X_test_prepared["rooms_per_household"] = (
+    X_test_prepared["total_rooms"] / X_test_prepared["households"]
+)
+X_test_prepared["bedrooms_per_room"] = (
+    X_test_prepared["total_bedrooms"] / X_test_prepared["total_rooms"]
+)
+X_test_prepared["population_per_household"] = (
+    X_test_prepared["population"] / X_test_prepared["households"]
+)
+
+X_test_cat = X_test[["ocean_proximity"]]
+X_test_prepared = X_test_prepared.join(pd.get_dummies(X_test_cat, drop_first=True))
+
+final_predictions = final_model.predict(X_test_prepared)
+final_mse = mean_squared_error(y_test, final_predictions)
+final_rmse = np.sqrt(final_mse)


### PR DESCRIPTION
Closes #5 

## Summary
This PR formats the `nonstandard_code.py` file using VSCode with the following tools:
- Formatter: Black
- Import sorter: isort
- Linter: flake8

All tools are configured to run on file save.

## VSCode Workspace Settings (`.vscode/settings.json`)
```json
{"python.pythonPath": "C:\Users\rahul.kumar2\Desktop\AI Associated Assignment\mle_training\mle-dev\Scripts\python.exe",
"editor.formatOnSave": true,
"python.sortImports.onSave": true,
"[python]": {
    "editor.defaultFormatter": "ms-python.python",
    "editor.codeActionsOnSave": {
        "source.organizeImports": true
    }
},
"python.linting.flake8Enabled": true,
"python.formatting.provider": "black",
"python.sortImports.path": "isort"
}